### PR TITLE
feat: HWB Color support

### DIFF
--- a/colors/hsbcolor.ts
+++ b/colors/hsbcolor.ts
@@ -1,4 +1,4 @@
-import { HexColor, HSLColor, RGBColor } from "./mod.ts";
+import { HexColor, HSLColor, HWBColor, RGBColor } from "./mod.ts";
 
 /** A color in HSB/HSV format. */
 export class HSBColor {
@@ -76,6 +76,19 @@ export class HSBColor {
         return new HSLColor(h, s, l, this.alpha);
     }
 
+    /** Converts the HSB Color to a HSL color. */
+    public toHWB(): HWBColor {
+        const h = this.hue;
+        let w = this.brightness * (1 - this.saturation);
+        let b = 1 - this.brightness;
+        if (w + b > 100) {
+            w /= 100;
+            b /= 100;
+        }
+
+        return new HWBColor(h, w, b, this.alpha);
+    }
+
     /** Gets the hue value of the color in degrees. */
     public get hue(): number {
         return this.h;
@@ -96,6 +109,7 @@ export class HSBColor {
         return this.a;
     }
 
+    /** Gets the HSBColor object as string. */
     public toString(): string {
         if (this.alpha) {
             return `hsba(${this.hue.toFixed(0)}°, ${(

--- a/colors/hslcolor.ts
+++ b/colors/hslcolor.ts
@@ -98,6 +98,7 @@ export class HSLColor {
         return this.a;
     }
 
+    /** Gets the HSLColor object as string. */
     public toString(): string {
         if (this.alpha) {
             return `hsla(${this.hue.toFixed(0)}°, ${(

--- a/colors/hwbcolor.ts
+++ b/colors/hwbcolor.ts
@@ -1,3 +1,5 @@
+import { HSBColor, RGBColor } from "./mod.ts";
+
 /** A color in HWB format. */
 export class HWBColor {
     private h: number;
@@ -11,6 +13,19 @@ export class HWBColor {
         this.w = w;
         this.b = b;
         this.a = a;
+    }
+
+    /** Converts the HWB color to a HSB color. */
+    public toHSB(): HSBColor {
+        const s = 1 - this.whiteness / (1 - this.blackness);
+        const b = 1 - this.blackness;
+
+        return new HSBColor(this.hue, s, b, this.alpha);
+    }
+
+    /** Converts the HWB color to a RGB color. */
+    public toRGB(): RGBColor {
+        return this.toHSB().toRGB();
     }
 
     /** Gets the hue value of the color in degrees. */
@@ -31,5 +46,20 @@ export class HWBColor {
     /** Gets the alpha value of the color if set. */
     public get alpha(): number | undefined {
         return this.a;
+    }
+
+    /** Gets the HWBColor object as string. */
+    public toString(): string {
+        if (this.alpha) {
+            return `hwba(${this.hue.toFixed(0)}°, ${(
+                this.whiteness * 100
+            ).toFixed(1)}%, ${(this.blackness * 100).toFixed(1)}%, ${
+                this.alpha
+            })`;
+        } else {
+            return `hwb(${this.hue.toFixed(0)}°, ${(
+                this.whiteness * 100
+            ).toFixed(1)}%, ${(this.blackness * 100).toFixed(1)}%)`;
+        }
     }
 }

--- a/colors/rgbcolor.ts
+++ b/colors/rgbcolor.ts
@@ -1,4 +1,4 @@
-import { HexColor, HSBColor, HSLColor } from "./mod.ts";
+import { HexColor, HSBColor, HSLColor, HWBColor } from "./mod.ts";
 
 /** A color in RGB format. */
 export class RGBColor {
@@ -80,6 +80,11 @@ export class RGBColor {
         const s = cMax === 0 ? 0 : delta / cMax;
 
         return new HSBColor(hsl.hue, s, cMax);
+    }
+
+    /** Converts the RGB color to a HWB color. */
+    public toHWB(): HWBColor {
+        return this.toHSB().toHWB();
     }
 
     /** Gets the red value. */

--- a/tests/hsbcolor.test.ts
+++ b/tests/hsbcolor.test.ts
@@ -22,3 +22,14 @@ Deno.test('test hsb_to_hsl', () => {
     const thirdColor = new HSBColor(100, 1, 1);
     assertEquals(thirdColor.toHSL().toString(), 'hsl(100°, 100.0%, 50.0%)');
 });
+
+Deno.test('test hsb_to_hwb', () => {
+    const hsbColor = new HSBColor(120, 1, 1);
+    assertEquals(hsbColor.toHWB().toString(), 'hwb(120°, 0.0%, 0.0%)');
+
+    const otherColor = new HSBColor(20, 0.667, 0.035);
+    assertEquals(otherColor.toHWB().toString(), 'hwb(20°, 1.2%, 96.5%)');
+
+    const thirdColor = new HSBColor(153, 0.152, 0.79);
+    assertEquals(thirdColor.toHWB().toString(), 'hwb(153°, 67.0%, 21.0%)');
+});

--- a/tests/hwbcolor.test.ts
+++ b/tests/hwbcolor.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from 'https://deno.land/std@0.146.0/testing/asserts.ts';
+import { HWBColor } from '../mod.ts';
+
+Deno.test('test hwb_to_hsb', () => {
+    const hwbColor = new HWBColor(120, 0, 0);
+    assertEquals(hwbColor.toHSB().toString(), 'hsb(120°, 100.0%, 100.0%)');
+
+    const otherColor = new HWBColor(153, 0.67, 0.21);
+    assertEquals(otherColor.toHSB().toString(), 'hsb(153°, 15.2%, 79.0%)');
+});
+
+Deno.test('test hwb_to_rgb', () => {
+    const hwbColor = new HWBColor(120, 0, 0);
+    assertEquals(hwbColor.toRGB().toString(), 'rgb(0, 255, 0)');
+
+    const otherColor = new HWBColor(153, 0.67, 0.21);
+    assertEquals(otherColor.toRGB().toString(), 'rgb(171, 201, 188)');
+});

--- a/tests/rgbcolor.test.ts
+++ b/tests/rgbcolor.test.ts
@@ -31,3 +31,14 @@ Deno.test('test rgb_to_hsb', () => {
     const thirdColor = new RGBColor(77, 246, 115);
     assertEquals(thirdColor.toHSB().toString(), 'hsb(133°, 68.7%, 96.5%)');
 });
+
+Deno.test('test rgb_to_hwb', () => {
+    const rgbColor = new RGBColor(255, 0, 0);
+    assertEquals(rgbColor.toHWB().toString(), 'hwb(0°, 0.0%, 0.0%)');
+
+    const secondColor = new RGBColor(0, 255, 0);
+    assertEquals(secondColor.toHWB().toString(), 'hwb(120°, 0.0%, 0.0%)');
+
+    const thirdColor = new RGBColor(77, 246, 115);
+    assertEquals(thirdColor.toHWB().toString(), 'hwb(133°, 30.2%, 3.5%)');
+});


### PR DESCRIPTION
This PR introduces support for HWB color conversion. This includes: HWB to HSB, HSB to HWB, HWB to RGB, and RGB to HWB. 